### PR TITLE
Agent options

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -18,12 +18,14 @@ module.exports = TestAgent;
  * Initialize a new `TestAgent`.
  *
  * @param {Function|Server} app
+ * @param {Object} options
  * @api public
  */
 
-function TestAgent(app){
-  if (!(this instanceof TestAgent)) return new TestAgent(app);
+function TestAgent(app, options){
+  if (!(this instanceof TestAgent)) return new TestAgent(app, options);
   if ('function' == typeof app) app = http.createServer(app);
+  if (options) this._ca = options.ca;
   Agent.call(this);
   this.app = app;
 }
@@ -38,6 +40,7 @@ TestAgent.prototype.__proto__ = Agent.prototype;
 methods.forEach(function(method){
   TestAgent.prototype[method] = function(url, fn){
     var req = new Test(this.app, method.toUpperCase(), url);
+    req.ca(this._ca);
 
     req.on('response', this.saveCookies.bind(this));
     req.on('redirect', this.saveCookies.bind(this));

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -4,9 +4,9 @@
  */
 
 var Agent = require('superagent').agent
-	, methods = require('methods')
-	, http = require('http')
-	, Test = require('./test');
+  , methods = require('methods')
+  , http = require('http')
+  , Test = require('./test');
 
 /**
  * Expose `Agent`.
@@ -22,10 +22,10 @@ module.exports = TestAgent;
  */
 
 function TestAgent(app){
-	if (!(this instanceof TestAgent)) return new TestAgent(app);
-	if ('function' == typeof app) app = http.createServer(app);
-	Agent.call(this);
-	this.app = app;
+  if (!(this instanceof TestAgent)) return new TestAgent(app);
+  if ('function' == typeof app) app = http.createServer(app);
+  Agent.call(this);
+  this.app = app;
 }
 
 /**


### PR DESCRIPTION
Should solve the problem I ran into on https://github.com/tj/supertest/issues/136 adding a CA cert to requests against a server.

This is a little noisier that it should be because I replaced some tabs with spaces.

Example usage:
```js
var request = require('supertest');
var https = require('https');
var fs = require('fs');
var path = require('path');
var express = require('express');

var app = express();
app.get('/', function(req, res){
  res.send('hey');
});

var server = https.createServer({
  key: fs.readFileSync(path.join(fixtures, 'test_key.pem')),
  cert: fs.readFileSync(path.join(fixtures, 'test_cert.pem'))
}, app);

var agent = request.agent(server, {ca: fs.readFileSync(path.join(fixtures, 'ca_root.crt'))}});

agent
  .get('/')
  .end(function(err, res){
    if (err) return done(err);
    // ... What ever here.
  });
```